### PR TITLE
Move prepublish command to node script, because of Windows issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build
 .DS_Store
 npm-debug.log*
 lerna-debug.log*
+
+# IDE
+.idea/*

--- a/packages/rockey-react/package.json
+++ b/packages/rockey-react/package.json
@@ -21,7 +21,7 @@
     "rockey": "^0.0.4"
   },
   "scripts": {
-    "prepublish": "../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel -d ./ ./lib",
-    "dev": "../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel -d ./ ./lib --watch"
+    "prepublish": "node tasks/prepublish.js",
+    "dev": "node tasks/prepublish.js --watch"
   }
 }

--- a/packages/rockey-react/tasks/prepublish.js
+++ b/packages/rockey-react/tasks/prepublish.js
@@ -1,0 +1,1 @@
+require('rockey/tasks/prepublish.js');

--- a/packages/rockey/package.json
+++ b/packages/rockey/package.json
@@ -23,7 +23,7 @@
     "utils"
   ],
   "scripts": {
-    "prepublish": "../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel -d ./ ./lib",
-    "dev": "../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel -d ./ ./lib --watch"
+    "prepublish": "node tasks/prepublish.js",
+    "dev": "node tasks/prepublish.js --watch"
   }
 }

--- a/packages/rockey/tasks/prepublish.js
+++ b/packages/rockey/tasks/prepublish.js
@@ -1,0 +1,15 @@
+/**
+ * Moved from npm prepublish command due to Windows issues
+ * original command was:
+ * // ../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel -d ./ ./lib
+ */
+const spawn = require('cross-spawn');
+
+const [node, path, ...args] = process.argv;
+
+spawn.sync('../../node_modules/.bin/babel', ['-d', './', './lib', ...args], {
+  stdio: 'inherit',
+  env: Object.assign({}, process.env, {
+    NODE_ENV: 'production'
+  })
+});


### PR DESCRIPTION
On Windows `lerna bootstrap` failing because of  ".." in
`"prepublish": "../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel -d ./ ./lib",`
So I moved this command to node script in tasks/prepublish and in package.json I run
`"prepublish": "node tasks/prepublish.js",`
