### PR TITLE
Add innerRef property

### DIFF
--- a/packages/rockey-react/lib/RockeyHoc.js
+++ b/packages/rockey-react/lib/RockeyHoc.js
@@ -8,6 +8,7 @@ import rule from 'rockey/rule';
 import look from './look';
 
 import RockeyHocWithHandlers from './utils/RockeyHocWithHandlers';
+import createElement from './utils/createElement';
 // import { flush } from 'rockey/styleSheets';
 
 import { ROCKEY_MIXIN_HANDLER_KEY } from './handler';
@@ -114,7 +115,8 @@ export const getRockeyHoc = () => {
           });
 
         case WAS_CALLED_AS_REACT_COMPONENT:
-          const props = args[0];
+          let { innerRef, ...props } = args[0];
+          props.ref = innerRef;
 
           if (!css) {
             css = createEmtpyCss(name);
@@ -165,7 +167,7 @@ export const getRockeyHoc = () => {
 
             const classList = finshCssRule.getClassList(props);
             const className = classnames(classList[name], props.className);
-            return React.createElement(BaseComponent, {
+            return createElement(BaseComponent, {
               ...props,
               className,
             });

--- a/packages/rockey-react/lib/assignShortcuts.js
+++ b/packages/rockey-react/lib/assignShortcuts.js
@@ -3,7 +3,6 @@ import 'react-dom';
 import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
 
-import filterProps from './utils/filterProps';
 import htmlTags from './htmlTags';
 
 const ucfirst = s => s.charAt(0).toUpperCase() + s.slice(1);
@@ -14,23 +13,18 @@ const assignShortcuts = rockey => {
     // ---- tag hoc lazy creation
     Object.defineProperty(rockey, tag, {
       get: () => (...args) => {
-        const TagComponent = props => {
-          return React.createElement(tag, filterProps(props));
-        };
-
         if (args.length === 1 && isString(args[0])) {
           // ---- use with defined displayName
-          return rockey(ucfirst(args[0]), TagComponent);
+          return rockey(ucfirst(args[0]), tag);
         } else if (isArray(args[0])) {
           // ---- use as anonymys tag shortcut
           if (!counter[tag]) {
             counter[tag] = 0;
           }
 
-          return rockey(
-            `Shortcut${ucfirst(tag)}${++counter[tag]}`,
-            TagComponent
-          )(...args);
+          return rockey(`Shortcut${ucfirst(tag)}${++counter[tag]}`, tag)(
+            ...args
+          );
         } else {
           throw new Error(
             `shortcut.${tag} used as React Component but without defined styles. Use jsx syntax directly for such cases - "<${tag}>...</${tag}>"`

--- a/packages/rockey-react/lib/utils/RockeyHocWithHandlers.js
+++ b/packages/rockey-react/lib/utils/RockeyHocWithHandlers.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
+import createElement from './createElement';
 
 const HANDLERS_SHOULD_BE_RESETED_ON_OUT = ['onMouseMove', 'onMouseOver'];
 const HANDLERS_SHOULD_BE_RESETED_ON_OVER = ['onMouseOut'];
@@ -116,8 +117,10 @@ export default class RockeyHocWithHandlers extends React.Component {
       };
     }
 
-    return (
-      <BaseComponent {...proxy} {...componentHandlers} className={className} />
-    );
+    return createElement(BaseComponent, {
+      ...proxy,
+      ...componentHandlers,
+      className,
+    });
   }
 }

--- a/packages/rockey-react/lib/utils/createElement.js
+++ b/packages/rockey-react/lib/utils/createElement.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import isString from 'lodash/isString';
+import filterProps from './filterProps';
+
+export default (type, props) => {
+  // filter props for HTML tags
+  return React.createElement(type, isString(type) ? filterProps(props) : props);
+};


### PR DESCRIPTION
Property has same behaviour as original ref in react.

For html shortcuts return DOM node:
```
const PrimaryButton = rockey.button('PrimaryButton');

// get button DOM element
<PrimaryButton innerRef={node => console.log(node)} />
```

For stateful components return instance:
```
class CustomComponent extends React.Component {
 ...
}

const CustomRockeyComponent = rockey(CustomComponent);

// get instance of CustomComponent
<CustomRockeyComponent innerRef={component => console.log(component)} />
```