### PR TITLE
[Benchmark] Update stylis to V3

### DIFF
--- a/packages/rockey-css-parse/package.json
+++ b/packages/rockey-css-parse/package.json
@@ -23,7 +23,7 @@
     "postcss": "^5.2.16",
     "postcss-nested": "^1.0.0",
     "postcss-safe-parser": "^2.0.0",
-    "stylis": "^2.0.4"
+    "stylis": "^3.0.5"
   },
   "dependencies": {
     "lodash": "^4.17.4"

--- a/packages/rockey-css-parse/tasks/benchmark-nested.js
+++ b/packages/rockey-css-parse/tasks/benchmark-nested.js
@@ -29,7 +29,7 @@ if (prevBestSizeTimings) {
 const modules = [
   'parse',
   'parseOptimized',
-  // 'stylis',
+  'stylis',
   'postcssNested',
   'postcssNestedSafeParser',
 ];


### PR DESCRIPTION
Update the version of stylis to V3

---

machine specs

```
1.3 GHz Intel Core i5
4 GB 1600 MHz DDR3
```

native test

```
Current results:
   1  stylis - 1.95sec
   2  postcssSafeParser - 4.962sec
   3  postcss - 5.871sec
   4  css - 6.872sec
```

nested test
```
Current results:
   1  stylis - 2.308sec
   2  parseOptimized - 5.426sec
   3  parse - 6.69sec
   4  postcssNestedSafeParser - 22.279sec
   5  postcssNested - 25.048sec
```

Getting the following error with rockey-parse for the native test, `(rockey-css-parse) duplicated keyframes "animation1"`