### PR TITLE
Add React 16 as a valid peer dependency

### DIFF
--- a/packages/rockey-react/package.json
+++ b/packages/rockey-react/package.json
@@ -32,8 +32,8 @@
     "rockey-react.min.js"
   ],
   "peerDependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^15.5.4 || ^16.0.0",
+    "react-dom": "^15.5.4 || ^16.0.0",
     "recompose": "^0.23.1"
   },
   "dependencies": {


### PR DESCRIPTION
`rockey` has been throwing peer dependency warnings, because it's used by `storybook-readme`. Everything seems ready for React 16, so adding the 16 range to the peer dependencies ought to be fine.